### PR TITLE
feat(core): first prototype of mask

### DIFF
--- a/projects/core/src/index.ts
+++ b/projects/core/src/index.ts
@@ -1,1 +1,2 @@
-export * from './lib/mask';
+export {Mask} from './lib/mask';
+export {MaskOptions} from './lib/types';

--- a/projects/core/src/lib/mask.ts
+++ b/projects/core/src/lib/mask.ts
@@ -1,5 +1,83 @@
+import {
+    adjustFixedMaskCharacters,
+    EventListener,
+    getClipboardDataText,
+    isEventProducingCharacter,
+    validateValueWithMask,
+} from './utils';
+import {MaskExpression, MaskOptions} from './types';
+
 export class Mask {
-    constructor(private readonly elementRef: HTMLInputElement | HTMLTextAreaElement) {
-        this.elementRef.value = this.elementRef.nodeName;
+    private readonly eventListener = new EventListener(this.elementRef);
+
+    constructor(
+        private readonly elementRef: HTMLInputElement | HTMLTextAreaElement,
+        private readonly options: MaskOptions,
+    ) {
+        this.eventListener.listen('focus', () => this.fillInputWithFixedValues());
+        /**
+         * After user press any button, events always happen in the same order as they are listed here.
+         * `Keydown`-event is useful for preprocessing (input is not changed yet, so you can easily prevent any changes).
+         * `Input`-event is useful for postprocessing (input was already changed, and you can add some fixed value).
+         */
+        this.eventListener.listen('keydown', event => this.handleKeydown(event));
+        this.eventListener.listen('paste', event => this.handlePaste(event));
+        this.eventListener.listen('input', () => this.fillInputWithFixedValues());
+    }
+
+    destroy(): void {
+        this.eventListener.destroy();
+    }
+
+    private get maskExpression(): MaskExpression {
+        const {mask} = this.options;
+
+        return typeof mask === 'function' ? mask() : mask;
+    }
+
+    private handleKeydown(event: KeyboardEvent): void {
+        this.fillInputWithFixedValues(event.key === 'Backspace');
+
+        /**
+         * "beforeinput" is more appropriate event for preprocessing of the input masking.
+         * But it is not supported by Chrome 49+ (only from 60+) and by Firefox 52+ (only from 87+).
+         * TODO: refactor with using "beforeinput" after browser support bump
+         *
+         * @see https://caniuse.com/?search=beforeinput
+         * @see https://taiga-ui.dev/browser-support
+         */
+        if (!isEventProducingCharacter(event)) {
+            return;
+        }
+
+        const currentValue = this.elementRef.value;
+        const caretPosition = this.elementRef.selectionStart || 0;
+        const newPossibleValue =
+            currentValue.slice(0, caretPosition) +
+            event.key +
+            currentValue.slice(caretPosition);
+
+        if (!validateValueWithMask(newPossibleValue, this.maskExpression)) {
+            event.preventDefault();
+        }
+    }
+
+    private handlePaste(event: ClipboardEvent): void {
+        // TODO: finish later
+        // eslint-disable-next-line no-console
+        console.log('===[handlePaste]===', event.cancelable, getClipboardDataText(event));
+    }
+
+    private fillInputWithFixedValues(isBackspace: boolean = false): void {
+        const {value} = this.elementRef;
+        const modifiedValue = adjustFixedMaskCharacters(
+            value,
+            this.maskExpression,
+            isBackspace,
+        );
+
+        if (modifiedValue !== value) {
+            this.elementRef.value = modifiedValue;
+        }
     }
 }

--- a/projects/core/src/lib/types/index.ts
+++ b/projects/core/src/lib/types/index.ts
@@ -1,0 +1,1 @@
+export * from './mask-options';

--- a/projects/core/src/lib/types/mask-options.ts
+++ b/projects/core/src/lib/types/mask-options.ts
@@ -1,0 +1,5 @@
+export type MaskExpression = Array<RegExp | string> | RegExp;
+
+export interface MaskOptions {
+    mask: MaskExpression | (() => MaskExpression);
+}

--- a/projects/core/src/lib/utils/dom/event-listener.ts
+++ b/projects/core/src/lib/utils/dom/event-listener.ts
@@ -1,0 +1,19 @@
+export class EventListener {
+    private readonly listeners: Array<() => void> = [];
+
+    constructor(private readonly element: HTMLElement) {}
+
+    listen<E extends keyof HTMLElementEventMap>(
+        eventType: E,
+        fn: (event: HTMLElementEventMap[E]) => unknown,
+        options?: AddEventListenerOptions,
+    ): void {
+        this.element.addEventListener<E>(eventType, fn, options);
+
+        this.listeners.push(() => this.element.removeEventListener(eventType, fn));
+    }
+
+    destroy(): void {
+        this.listeners.forEach(stopListen => stopListen());
+    }
+}

--- a/projects/core/src/lib/utils/dom/get-clipboard-data-text.ts
+++ b/projects/core/src/lib/utils/dom/get-clipboard-data-text.ts
@@ -1,0 +1,14 @@
+const DEFAULT_FORMAT = `text/plain`;
+
+/**
+ * Gets text from data of clipboardEvent
+ */
+export function getClipboardDataText(
+    event: ClipboardEvent,
+    format: string = DEFAULT_FORMAT,
+): string {
+    return `clipboardData` in event && event.clipboardData !== null
+        ? event.clipboardData.getData(format) ||
+              event.clipboardData.getData(DEFAULT_FORMAT)
+        : (event as any).target.ownerDocument.defaultView.clipboardData.getData(`text`);
+}

--- a/projects/core/src/lib/utils/dom/is-event-producing-character.ts
+++ b/projects/core/src/lib/utils/dom/is-event-producing-character.ts
@@ -1,0 +1,11 @@
+export function isEventProducingCharacter({
+    key,
+    ctrlKey,
+    metaKey,
+    altKey,
+}: KeyboardEvent): boolean {
+    const isSystemKeyCombinations = ctrlKey || metaKey || altKey;
+    const isSingleUnicodeChar = /^.$/u.test(key); // 4-byte characters case (e.g. smile)
+
+    return !isSystemKeyCombinations && key !== 'Backspace' && isSingleUnicodeChar;
+}

--- a/projects/core/src/lib/utils/index.ts
+++ b/projects/core/src/lib/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './dom/event-listener';
+export * from './dom/get-clipboard-data-text';
+export * from './dom/is-event-producing-character';
+
+export * from './mask-validation/adjust-fixed-mask-characters';
+export * from './mask-validation/validate-value-with-mask';

--- a/projects/core/src/lib/utils/mask-validation/adjust-fixed-mask-characters.ts
+++ b/projects/core/src/lib/utils/mask-validation/adjust-fixed-mask-characters.ts
@@ -1,0 +1,63 @@
+import {MaskExpression} from '../../types';
+
+export function adjustFixedMaskCharacters(
+    value: string,
+    mask: MaskExpression,
+    isBackspaced = false,
+): string {
+    if (!Array.isArray(mask)) {
+        return value;
+    }
+
+    const formattedValue = [
+        ...Array.from(value),
+        '', // extra iteration to take all tailed fixed characters
+    ].reduce((acc, char, charIndex) => {
+        let formattedFinalString = acc;
+
+        for (let i = charIndex; i < mask.length; i++) {
+            const charConstraint = mask[i];
+            const isFixedChar = typeof charConstraint === 'string';
+
+            if (!isFixedChar || charConstraint === char) {
+                return formattedFinalString + char;
+            }
+
+            formattedFinalString += charConstraint;
+        }
+
+        return formattedFinalString;
+    }, '');
+
+    if (!isBackspaced) {
+        return formattedValue;
+    }
+
+    return formattedValue.slice(
+        0,
+        formattedValue.length - getTailedFixedValues(formattedValue, mask).length,
+    );
+}
+
+function getTailedFixedValues(
+    value: string,
+    mask: MaskExpression,
+    prevAccumulatedValue = '',
+): string {
+    if (!Array.isArray(mask)) {
+        return '';
+    }
+
+    const lastCharIndex = value.length - 1;
+    const lastCharConstraint = mask[lastCharIndex];
+
+    if (typeof lastCharConstraint !== 'string') {
+        return prevAccumulatedValue;
+    }
+
+    return getTailedFixedValues(
+        value.slice(0, lastCharIndex),
+        mask,
+        lastCharConstraint + prevAccumulatedValue,
+    );
+}

--- a/projects/core/src/lib/utils/mask-validation/validate-value-with-mask.ts
+++ b/projects/core/src/lib/utils/mask-validation/validate-value-with-mask.ts
@@ -1,0 +1,21 @@
+import {MaskExpression} from '../../types';
+
+export function validateValueWithMask(
+    value: string,
+    maskExpression: MaskExpression,
+): boolean {
+    if (Array.isArray(maskExpression)) {
+        return (
+            value.length <= maskExpression.length &&
+            Array.from(value).every((char, i) => {
+                const charConstraint = maskExpression[i];
+
+                return typeof charConstraint === 'string'
+                    ? char === charConstraint
+                    : char.match(charConstraint);
+            })
+        );
+    }
+
+    return maskExpression.test(value);
+}

--- a/projects/demo/src/app/modules/sandbox/masks.ts
+++ b/projects/demo/src/app/modules/sandbox/masks.ts
@@ -1,0 +1,22 @@
+export const INPUT_NUMBER_MASK = /^\d+(\.\d*)?$/;
+export const INPUT_PHONE_MASK = [
+    '+',
+    '7',
+    ' ',
+    '(',
+    /\d/,
+    /\d/,
+    /\d/,
+    ')',
+    ' ',
+    /\d/,
+    /\d/,
+    /\d/,
+    '-',
+    /\d/,
+    /\d/,
+    '-',
+    /\d/,
+    /\d/,
+];
+export const NO_CYRILLIC_MASK = /^[^а-я]+$/i;

--- a/projects/demo/src/app/modules/sandbox/sandbox.component.ts
+++ b/projects/demo/src/app/modules/sandbox/sandbox.component.ts
@@ -3,9 +3,11 @@ import {
     ChangeDetectionStrategy,
     Component,
     ElementRef,
+    OnDestroy,
     ViewChild,
 } from '@angular/core';
 import {Mask} from '@maskito/core';
+import {INPUT_NUMBER_MASK, INPUT_PHONE_MASK, NO_CYRILLIC_MASK} from './masks';
 
 @Component({
     selector: 'sandbox',
@@ -13,18 +15,35 @@ import {Mask} from '@maskito/core';
     styleUrls: ['./sandbox.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SandboxComponent implements AfterViewInit {
-    @ViewChild('inputRef')
-    private readonly inputRef!: ElementRef<HTMLInputElement>;
+export class SandboxComponent implements AfterViewInit, OnDestroy {
+    @ViewChild('inputNumber')
+    private readonly inputNumberRef!: ElementRef<HTMLInputElement>;
+
+    @ViewChild('inputPhone')
+    private readonly inputPhoneRef!: ElementRef<HTMLInputElement>;
 
     @ViewChild('textAreaRef')
     private readonly textAreaRef!: ElementRef<HTMLTextAreaElement>;
 
-    ngAfterViewInit() {
-        const maskedInput = new Mask(this.inputRef.nativeElement);
-        const maskedTextArea = new Mask(this.textAreaRef.nativeElement);
+    private maskedInputPhone: Mask | null = null;
+    private maskedInputNumber: Mask | null = null;
+    private maskedTextArea: Mask | null = null;
 
-        // eslint-disable-next-line no-console
-        console.log(maskedInput, maskedTextArea);
+    ngAfterViewInit() {
+        this.maskedInputPhone = new Mask(this.inputPhoneRef.nativeElement, {
+            mask: INPUT_PHONE_MASK,
+        });
+        this.maskedInputNumber = new Mask(this.inputNumberRef.nativeElement, {
+            mask: INPUT_NUMBER_MASK,
+        });
+        this.maskedTextArea = new Mask(this.textAreaRef.nativeElement, {
+            mask: NO_CYRILLIC_MASK,
+        });
+    }
+
+    ngOnDestroy() {
+        this.maskedInputPhone?.destroy();
+        this.maskedInputNumber?.destroy();
+        this.maskedTextArea?.destroy();
     }
 }

--- a/projects/demo/src/app/modules/sandbox/sandbox.template.html
+++ b/projects/demo/src/app/modules/sandbox/sandbox.template.html
@@ -1,9 +1,17 @@
 <input
-    #inputRef
+    #inputNumber
+    placeholder="InputNumber"
+    class="prettify"
+/>
+
+<input
+    #inputPhone
+    placeholder="InputPhone"
     class="prettify"
 />
 
 <textarea
     #textAreaRef
+    placeholder="Cyrillic symbols are not allowed"
     class="prettify"
 ></textarea>


### PR DESCRIPTION
## Proposed API
### Public API:
```ts
type MaskExpression = Array<RegExp | string> | RegExp;

export interface MaskOptions {
    mask: MaskExpression | (() => MaskExpression);
    // more options
}

export declare class Mask {
    constructor(elementRef: HTMLInputElement | HTMLTextAreaElement, options: MaskOptions);
    destroy(): void;
}
```

### Usage examples
#### 1. InputPhone
```ts
import {Mask} from '@maskito/core';

const inputRef: HTMLInputElement = document.querySelector('input.css-selector');

const MASK = [
    '+', '7', ' ', '(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, '-', /\d/, /\d/
]

const inputPhone = new Mask(
    this.inputRef,
    { mask: MASK }
);
```

#### 2. InputNumber
```ts
import {Mask} from '@maskito/core';

const inputRef: HTMLInputElement = document.querySelector('input.css-selector');

const inputNumber = new Mask(
    this.inputRef,
    { mask: /^\d+(\.\d*)?$/ }
);
```

#### 3. InputDate
```ts
import {Mask, MaskOptions} from '@maskito/core';

const inputRef: HTMLInputElement = document.querySelector('input.css-selector');

const generateDateMaskExpression = (dateMode: 'DMY' | 'YMD' | 'MDY'): MaskOptions['mask'] => {
    switch (dateMode) {
        case 'MDY':
            return []; // Array<RegExp | string>
        case "YMD":
            return /.../; // RegExp
        default:
            return []; // Array<RegExp | string>
    }
}

const inputDate = new Mask(
    this.inputRef,
    { mask: generateDateMaskExpression('DMY') }
);
```