### PR TITLE
refactor(kit): use `beforeinput`-event (listen to `keydown` + `paste` only for legacy browsers)

### DIFF
--- a/projects/core/src/lib/classes/mask-model/mask-model.ts
+++ b/projects/core/src/lib/classes/mask-model/mask-model.ts
@@ -27,9 +27,10 @@ export class MaskModel {
     }
 
     addCharacters(selection: SelectionRange, newCharacters: string): void {
+        const {maskExpression, value} = this;
         const unmaskedElementState = removeFixedMaskCharacters(
-            {value: this.value, selection},
-            this.maskExpression,
+            {value, selection},
+            maskExpression,
         );
         const [unmaskedFrom, unmaskedTo] = unmaskedElementState.selection;
         const newUnmaskedValue =
@@ -43,10 +44,10 @@ export class MaskModel {
                 value: newUnmaskedValue,
                 selection: [newCaretIndex, newCaretIndex],
             },
-            this.maskExpression,
+            maskExpression,
         );
 
-        if (!validateValueWithMask(maskedElementState.value, this.maskExpression)) {
+        if (!validateValueWithMask(maskedElementState.value, maskExpression)) {
             throw new Error('Invalid mask value');
         }
 
@@ -63,9 +64,10 @@ export class MaskModel {
             throw new Error('MaskModel.removeCharacters() accepts only not-empty range');
         }
 
+        const {maskExpression, value} = this;
         const unmaskedElementState = removeFixedMaskCharacters(
-            {value: this.value, selection: [from, to]},
-            this.maskExpression,
+            {value, selection: [from, to]},
+            maskExpression,
         );
         const [unmaskedFrom, unmaskedTo] = unmaskedElementState.selection;
         const newUnmaskedValue =
@@ -74,7 +76,7 @@ export class MaskModel {
 
         const maskedElementState = addFixedMaskCharacters(
             {value: newUnmaskedValue, selection: [unmaskedFrom, unmaskedFrom]},
-            this.maskExpression,
+            maskExpression,
         );
 
         this.value = maskedElementState.value;

--- a/projects/core/src/lib/mask.ts
+++ b/projects/core/src/lib/mask.ts
@@ -1,4 +1,8 @@
-import {EventListener, isEventProducingCharacter} from './utils';
+import {
+    EventListener,
+    isBeforeInputEventSupported,
+    isEventProducingCharacter,
+} from './utils';
 import {ElementState, MaskitoOptions, SelectionRange} from './types';
 import {MaskModel} from './classes';
 
@@ -9,16 +13,49 @@ export class Maskito {
         private readonly element: HTMLInputElement | HTMLTextAreaElement,
         private readonly options: MaskitoOptions,
     ) {
-        this.fillWithFixedValues();
+        this.conformValueToMask();
+
+        if (!isBeforeInputEventSupported(element)) {
+            // as an alternative to `beforeinput`-event for legacy browsers
+            // TODO: drop it after browser support bump
+            this.eventListener.listen('keydown', event => this.handleKeydown(event));
+            this.eventListener.listen('paste', event =>
+                this.handlePaste(event, event.clipboardData?.getData('text/plain') || ''),
+            );
+        }
 
         /**
-         * After user press any button, events always happen in the same order as they are listed here.
-         * `Keydown`-event is useful for validation (input is not changed yet, so you can easily prevent any changes).
-         * `Input`-event is useful for postprocessing (input was already changed, and you can add some fixed value).
+         * `beforeinput`-event is useful for validation (input is not changed yet, so you can easily prevent any changes).
+         * `input`-event is useful for postprocessing (input was already changed, and you can add some fixed value).
          */
-        this.eventListener.listen('keydown', event => this.handleKeydown(event));
-        this.eventListener.listen('paste', event => this.handlePaste(event));
-        this.eventListener.listen('input', () => this.fillWithFixedValues());
+        this.eventListener.listen('beforeinput', event => {
+            switch (event.inputType) {
+                case 'deleteContentBackward':
+                case 'deleteWordBackward': // TODO
+                case 'deleteByCut':
+                    return this.handleDelete(event, false);
+                case 'deleteContentForward':
+                case 'deleteWordForward': // TODO
+                    return this.handleDelete(event, true);
+                case 'insertFromDrop':
+                    // We don't know caret position at this moment
+                    // (inserted content will be handled later in "input"-event)
+                    return;
+                case 'insertFromPaste':
+                    return this.handlePaste(event, event.data || '');
+                case 'insertText':
+                default:
+                    try {
+                        new MaskModel(this.elementState, this.options).addCharacters(
+                            this.elementState.selection,
+                            event.data || '',
+                        );
+                    } catch {
+                        event.preventDefault();
+                    }
+            }
+        });
+        this.eventListener.listen('input', () => this.conformValueToMask());
     }
 
     destroy(): void {
@@ -34,9 +71,6 @@ export class Maskito {
         };
     }
 
-    /**
-     * TODO Predictive text from native mobile keyboards don't trigger keydown event!
-     */
     private handleKeydown(event: KeyboardEvent): void {
         const pressedKey = event.key;
 
@@ -44,14 +78,6 @@ export class Maskito {
             return this.handleDelete(event, pressedKey === 'Delete');
         }
 
-        /**
-         * "beforeinput" is more appropriate event for preprocessing of the input masking.
-         * But it is not supported by Chrome 49+ (only from 60+) and by Firefox 52+ (only from 87+).
-         * TODO: refactor with using "beforeinput" after browser support bump
-         *
-         * @see https://caniuse.com/?search=beforeinput
-         * @see https://taiga-ui.dev/browser-support
-         */
         if (!isEventProducingCharacter(event)) {
             return;
         }
@@ -65,14 +91,14 @@ export class Maskito {
         }
     }
 
-    private fillWithFixedValues(): void {
+    private conformValueToMask(): void {
         const maskModel = new MaskModel(this.elementState, this.options);
 
         this.updateValue(maskModel.value);
         this.updateSelectionRange(maskModel.selection);
     }
 
-    private handleDelete(event: KeyboardEvent, isForward: boolean): void {
+    private handleDelete(event: Event, isForward: boolean): void {
         const {elementState, options} = this;
 
         if (!Array.isArray(options.mask)) {
@@ -102,10 +128,9 @@ export class Maskito {
         this.updateSelectionRange(selection);
     }
 
-    private handlePaste(event: ClipboardEvent): void {
+    private handlePaste(event: Event, insertedText: string): void {
         const {elementState, options} = this;
         const maskModel = new MaskModel(elementState, options);
-        const insertedText = event.clipboardData?.getData('text/plain') ?? '';
 
         try {
             maskModel.addCharacters(elementState.selection, insertedText);

--- a/projects/core/src/lib/types/index.ts
+++ b/projects/core/src/lib/types/index.ts
@@ -1,3 +1,4 @@
 export * from './element-state';
 export * from './mask-options';
 export * from './selection-range';
+export * from './typed-input-event';

--- a/projects/core/src/lib/types/typed-input-event.ts
+++ b/projects/core/src/lib/types/typed-input-event.ts
@@ -1,0 +1,15 @@
+export interface TypedInputEvent extends InputEvent {
+    inputType:
+        | 'insertText'
+        | 'insertReplacementText'
+        | 'insertCompositionText'
+        | 'deleteContentBackward' // Backspace
+        | 'deleteContentForward' // Delete (Fn + Backspace)
+        | 'deleteWordBackward' // Alt (Option) + Backspace
+        | 'deleteWordForward' // Alt (Option) + Delete (Fn + Backspace)
+        | 'deleteByCut' // Ctrl (Command) + X
+        | 'insertFromPaste' // Ctrl (Command) + V
+        | 'insertFromDrop'
+        | 'historyUndo' // Ctrl (Command) + Z
+        | 'historyRedo'; // Ctrl (Command) + Shift + Z
+}

--- a/projects/core/src/lib/utils/dom/event-listener.ts
+++ b/projects/core/src/lib/utils/dom/event-listener.ts
@@ -1,3 +1,5 @@
+import {TypedInputEvent} from '../../types';
+
 export class EventListener {
     private readonly listeners: Array<() => void> = [];
 
@@ -5,12 +7,15 @@ export class EventListener {
 
     listen<E extends keyof HTMLElementEventMap>(
         eventType: E,
-        fn: (event: HTMLElementEventMap[E]) => unknown,
+        fn: (
+            event: E extends 'beforeinput' ? TypedInputEvent : HTMLElementEventMap[E],
+        ) => unknown,
         options?: AddEventListenerOptions,
     ): void {
-        this.element.addEventListener<E>(eventType, fn, options);
+        const untypedFn = fn as (event: HTMLElementEventMap[E]) => unknown;
 
-        this.listeners.push(() => this.element.removeEventListener(eventType, fn));
+        this.element.addEventListener<E>(eventType, untypedFn, options);
+        this.listeners.push(() => this.element.removeEventListener(eventType, untypedFn));
     }
 
     destroy(): void {

--- a/projects/core/src/lib/utils/dom/is-before-input-event-supported.ts
+++ b/projects/core/src/lib/utils/dom/is-before-input-event-supported.ts
@@ -1,0 +1,16 @@
+/**
+ * "beforeinput" is more appropriate event for preprocessing of the input masking (than `keydown`):
+ * - `keydown` is not triggered by predictive text from native mobile keyboards.
+ * - `keydown` is triggered by system key combinations (we don't need them, and they should be manually filtered).
+ * - Dropping text inside input triggers `beforeinput` (but not `keydown`).
+ * ___
+ * "beforeinput" is not supported by Chrome 49+ (only from 60+) and by Firefox 52+ (only from 87+).
+ *
+ * @see https://caniuse.com/?search=beforeinput
+ * @see https://taiga-ui.dev/browser-support
+ */
+export function isBeforeInputEventSupported(
+    element: HTMLInputElement | HTMLTextAreaElement,
+): boolean {
+    return 'onbeforeinput' in element;
+}

--- a/projects/core/src/lib/utils/index.ts
+++ b/projects/core/src/lib/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './dom/event-listener';
+export * from './dom/is-before-input-event-supported';
 export * from './dom/is-event-producing-character';

--- a/projects/demo-integrations/cypress/tests/sandbox/input-phone.cy.ts
+++ b/projects/demo-integrations/cypress/tests/sandbox/input-phone.cy.ts
@@ -338,14 +338,10 @@ describe('InputPhone', () => {
 
         describe('Select range and press "Delete"', () => {
             it('+7 (912) 345-67-|89| => Delete => +7 (912) 345-67|', () => {
-                cy.get('@inputPhone').realPress([
-                    'Shift',
-                    'ArrowLeft',
-                    'ArrowLeft',
-                    'Delete',
-                ]);
+                cy.get('@inputPhone').realPress(['Shift', 'ArrowLeft', 'ArrowLeft']);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 345-67')
                     .should('have.prop', 'selectionStart', '+7 (912) 345-67'.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) 345-67'.length);
@@ -355,10 +351,10 @@ describe('InputPhone', () => {
                 cy.get('@inputPhone').realPress([
                     'Shift',
                     ...Array('7-89'.length).fill('ArrowLeft'),
-                    'Delete',
                 ]);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 345-6')
                     .should('have.prop', 'selectionStart', '+7 (912) 345-6'.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) 345-6'.length);
@@ -369,10 +365,10 @@ describe('InputPhone', () => {
                     'ArrowLeft',
                     'Shift',
                     ...Array('7-8'.length).fill('ArrowLeft'),
-                    'Delete',
                 ]);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 345-69')
                     .should('have.prop', 'selectionStart', '+7 (912) 345-6'.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) 345-6'.length);
@@ -383,10 +379,10 @@ describe('InputPhone', () => {
                     ...Array('-89'.length).fill('ArrowLeft'),
                     'Shift',
                     ...Array('67'.length).fill('ArrowLeft'),
-                    'Delete',
                 ]);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 345-89')
                     .should('have.prop', 'selectionStart', '+7 (912) 345-'.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) 345-'.length);
@@ -397,10 +393,10 @@ describe('InputPhone', () => {
                     ...Array('-67-89'.length).fill('ArrowLeft'),
                     'Shift',
                     ...Array('345'.length).fill('ArrowLeft'),
-                    'Delete',
                 ]);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 678-9')
                     .should('have.prop', 'selectionStart', '+7 (912) '.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) '.length);
@@ -494,10 +490,10 @@ describe('InputPhone', () => {
                     ...Array('345-67-89'.length).fill('ArrowLeft'),
                     'Shift',
                     ...Array(') '.length).fill('ArrowLeft'),
-                    'Delete',
                 ]);
 
                 cy.get('@inputPhone')
+                    .type('{del}')
                     .should('have.value', '+7 (912) 345-67-89')
                     .should('have.prop', 'selectionStart', '+7 (912) '.length)
                     .should('have.prop', 'selectionEnd', '+7 (912) '.length);


### PR DESCRIPTION
"beforeinput"-event is more appropriate event for preprocessing of the input masking (than `keydown`):
- `keydown` **is not triggered by predictive text from native mobile keyboards**.
- `keydown` is triggered by system key combinations (we don't need them, and they should be manually filtered).
- Dropping text inside input triggers `beforeinput` (but not `keydown`).

Closes #9