### PR TITLE
fix(core): `globalThis` Reference error +  new `Browser support` documentation page

### DIFF
--- a/projects/core/src/lib/mask.ts
+++ b/projects/core/src/lib/mask.ts
@@ -70,7 +70,7 @@ export class Maskito extends MaskHistory {
                 }
             });
         } else {
-            /** TODO: drop it after browser support bump
+            /** TODO: drop it after browser support bump (Firefox 87+)
              * Also, replace union types `Event | TypedInputEvent` with `TypedInputEvent` inside:
              *** {@link handleDelete}
              *** {@link handleInsert}
@@ -244,9 +244,13 @@ export class Maskito extends MaskHistory {
         },
     ): void {
         if (this.element.value !== newValue) {
+            const globalObject = typeof window !== 'undefined' ? window : globalThis;
+
             this.element.value = newValue;
 
-            if (globalThis.InputEvent) {
+            // TODO: replace `globalObject` with `globalThis` after bumping Firefox to 65+
+            // @see https://caniuse.com/?search=globalThis
+            if (globalObject?.InputEvent) {
                 this.element.dispatchEvent(
                     new InputEvent('input', {
                         ...eventInit,

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import {SandboxComponent} from './modules/sandbox/sandbox.component';
 
 export const enum DemoPath {
     Time = 'kit/time',
+    BrowserSupport = 'documentation/browser-support',
 }
 
 export const appRoutes: Routes = [
@@ -13,6 +14,16 @@ export const appRoutes: Routes = [
         component: SandboxComponent,
         data: {
             title: `Sandbox`,
+        },
+    },
+    {
+        path: DemoPath.BrowserSupport,
+        loadChildren: () =>
+            import(`../pages/documentation/browser-support/browser-support.module`).then(
+                m => m.BrowserSupportModule,
+            ),
+        data: {
+            title: `Browser support`,
         },
     },
     {

--- a/projects/demo/src/pages/documentation/browser-support/browser-support.component.ts
+++ b/projects/demo/src/pages/documentation/browser-support/browser-support.component.ts
@@ -1,0 +1,26 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+    selector: 'browser-support',
+    templateUrl: './browser-support.template.html',
+    styles: ['td {width: 18.75rem}'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BrowserSupportComponent {
+    readonly desktopBrowsers = [
+        {name: 'Google Chrome', version: '74+'},
+        {name: 'Mozilla Firefox', version: '55+'},
+        {name: 'Safari', version: '12.1+'},
+        {name: 'Opera', version: '62+'},
+        {name: 'Edge (Chromium)', version: '74+'},
+        {name: 'Microsoft Internet Explorer', version: null},
+        {name: 'Edge (EdgeHTML)', version: null},
+    ] as const;
+
+    readonly mobileBrowsers = [
+        {name: 'Google Chrome', version: '90+'},
+        {name: 'Mozilla Firefox', version: '99+'},
+        {name: 'Safari', version: '12.2+'},
+        {name: 'Opera', version: '64+'},
+    ];
+}

--- a/projects/demo/src/pages/documentation/browser-support/browser-support.module.ts
+++ b/projects/demo/src/pages/documentation/browser-support/browser-support.module.ts
@@ -1,0 +1,16 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {TuiAddonDocModule, tuiGenerateRoutes} from '@taiga-ui/addon-doc';
+import {BrowserSupportComponent} from './browser-support.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        TuiAddonDocModule,
+        RouterModule.forChild(tuiGenerateRoutes(BrowserSupportComponent)),
+    ],
+    declarations: [BrowserSupportComponent],
+    exports: [BrowserSupportComponent],
+})
+export class BrowserSupportModule {}

--- a/projects/demo/src/pages/documentation/browser-support/browser-support.template.html
+++ b/projects/demo/src/pages/documentation/browser-support/browser-support.template.html
@@ -1,0 +1,42 @@
+<tui-doc-page header="Browser support">
+    <h1 class="tui-text_h4 tui-space_top-0 tui-space_bottom-3">Desktop</h1>
+    <table class="tui-table">
+        <tbody>
+            <tr class="tui-table__tr">
+                <th class="tui-table__th">Browser</th>
+                <th class="tui-table__th">Version</th>
+            </tr>
+            <tr
+                *ngFor="let browser of desktopBrowsers"
+                class="tui-table__tr"
+            >
+                <td class="tui-table__td">{{ browser.name }}</td>
+                <td class="tui-table__td">
+                    <ng-container *ngIf="browser.version; else notSupported">
+                        {{ browser.version }}
+                    </ng-container>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <h1 class="tui-text_h4 tui-space_top-6 tui-space_bottom-3">Mobile</h1>
+    <table class="tui-table">
+        <tbody>
+            <tr class="tui-table__tr">
+                <th class="tui-table__th">Browser</th>
+                <th class="tui-table__th">Version</th>
+            </tr>
+            <tr
+                *ngFor="let browser of mobileBrowsers"
+                class="tui-table__tr"
+            >
+                <td class="tui-table__td">{{ browser.name }}</td>
+                <td class="tui-table__td">{{ browser.version }}</td>
+            </tr>
+        </tbody>
+    </table>
+</tui-doc-page>
+
+<ng-template #notSupported>
+    <strong>Not supported</strong>
+</ng-template>

--- a/projects/demo/src/pages/pages.ts
+++ b/projects/demo/src/pages/pages.ts
@@ -3,6 +3,12 @@ import {DemoPath} from '../app/app.routes';
 
 export const DEMO_PAGES: TuiDocPages = [
     {
+        section: 'Documentation',
+        title: 'Browser support',
+        route: DemoPath.BrowserSupport,
+        keywords: `chrome, safari, ie, edge, firefox`,
+    },
+    {
         section: 'Kit',
         title: 'Time',
         route: DemoPath.Time,


### PR DESCRIPTION
Open any ancient browser (with [no globalThis support](https://caniuse.com/?search=globalThis)).
For example: Firefox 64.

```
ReferenceError: globalThis is not defined
```