### PR TITLE
ci: `tsconfig` option `compilerOptions.lib` use `es2017`

### DIFF
--- a/projects/kit/src/lib/masks/time/utils/pad-time-segments.ts
+++ b/projects/kit/src/lib/masks/time/utils/pad-time-segments.ts
@@ -1,3 +1,4 @@
+import {getObjectFromEntries} from '../../../utils';
 import {TIME_SEGMENT_VALUE_LENGTHS} from '../constants';
 import {MaskitoTimeSegments} from '../types';
 
@@ -12,7 +13,7 @@ export function padTimeSegments(
 export function padTimeSegments(
     timeSegments: Partial<MaskitoTimeSegments<number | string>>,
 ): Partial<MaskitoTimeSegments> {
-    return Object.fromEntries(
+    return getObjectFromEntries(
         Object.entries(timeSegments).map(([segmentName, segmentValue]) => [
             segmentName,
             `${segmentValue}`.padEnd(

--- a/projects/kit/src/lib/masks/time/utils/parse-time-string.ts
+++ b/projects/kit/src/lib/masks/time/utils/parse-time-string.ts
@@ -1,3 +1,4 @@
+import {getObjectFromEntries} from '../../../utils';
 import {MaskitoTimeSegments} from '../types';
 
 /**
@@ -13,7 +14,7 @@ export function parseTimeString(timeString: string): Partial<MaskitoTimeSegments
         milliseconds: onlyDigits.slice(6, 9),
     };
 
-    return Object.fromEntries(
+    return getObjectFromEntries(
         Object.entries(timeSegments).filter(([_, value]) => Boolean(value)),
     );
 }

--- a/projects/kit/src/lib/processors/valid-date-preprocessor.ts
+++ b/projects/kit/src/lib/processors/valid-date-preprocessor.ts
@@ -63,7 +63,7 @@ export function createValidDatePreprocessor(
                         .join(separator) +
                     validatedValue.slice(to),
             },
-            data: newData.replaceAll(separator, ''),
+            data: newData.replace(new RegExp(separator, 'g'), ''),
         };
     };
 }

--- a/projects/kit/src/lib/processors/valid-date-preprocessor.ts
+++ b/projects/kit/src/lib/processors/valid-date-preprocessor.ts
@@ -63,7 +63,7 @@ export function createValidDatePreprocessor(
                         .join(separator) +
                     validatedValue.slice(to),
             },
-            data: newData.replace(new RegExp(separator, 'g'), ''),
+            data: newData.replace(new RegExp(`\\${separator}`, 'g'), ''),
         };
     };
 }

--- a/projects/kit/src/lib/utils/get-object-from-entries.ts
+++ b/projects/kit/src/lib/utils/get-object-from-entries.ts
@@ -1,0 +1,16 @@
+/**
+ * @deprecated use `Object.fromEntries` instead
+ * (check browser support first https://caniuse.com/mdn-javascript_builtins_object_fromentries)
+ * ___
+ * TODO: after we bump Firefox to 63+ replace this function with `Object.fromEntries`.
+ * TODO: Add `es2019.object` to `tsconfig.json` => `compilerOptions.lib`.
+ *
+ */
+export function getObjectFromEntries<K extends number | string, V>(
+    keyValuePairs: Array<[K, V]>,
+): Record<K, V> {
+    return keyValuePairs.reduce(
+        (obj, [key, val]) => ({...obj, [key]: val}),
+        {} as Record<K, V>,
+    );
+}

--- a/projects/kit/src/lib/utils/index.ts
+++ b/projects/kit/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './date-segment-value-length';
+export * from './get-object-from-entries';
 export * from './pad-with-zeroes-until-valid';
 export * from './parse-date-string';
 export * from './to-date-string';

--- a/projects/kit/src/lib/utils/parse-date-string.ts
+++ b/projects/kit/src/lib/utils/parse-date-string.ts
@@ -1,4 +1,5 @@
 import {MaskitoDateSegments} from '../types';
+import {getObjectFromEntries} from './get-object-from-entries';
 
 export function parseDateString(
     dateString: string,
@@ -17,7 +18,7 @@ export function parseDateString(
         year: onlyDigitsDate.slice(yearIndex, cleanMode.lastIndexOf('y') + 1),
     };
 
-    return Object.fromEntries(
+    return getObjectFromEntries(
         Object.entries(dateSegments)
             .filter(([_, value]) => Boolean(value))
             .sort(([a], [b]) =>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,7 +31,7 @@
         "noUnusedLocals": true,
         "target": "es2015",
         "typeRoots": ["node_modules/@types"],
-        "lib": ["esnext", "dom"],
+        "lib": ["es2017", "es2018.asynciterable", "dom"],
         "paths": {
             "@maskito/angular": ["projects/angular/src/index.ts"],
             "@maskito/core": ["projects/core/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
Developer can mistakenly use ES-features which are not supported by all required browsers.
And there will be no error!

See https://tinkoff.github.io/maskito/documentation/browser-support

## What is the new behavior?
User can't use not-supported features.
Typescript throws error for them:
<img width="1134" alt="Screenshot 2023-02-02 at 12 37 02" src="https://user-images.githubusercontent.com/35179038/216287395-c86f49ec-5e27-497b-851b-350687705e52.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
