### PR TITLE
ci: run prettier after `Changelog`-generation during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     },
     "standard-version": {
         "scripts": {
+            "postchangelog": "ts-node ./scripts/postchangelog.ts",
             "postbump": "node scripts/syncVersions.js && git add **/package.json"
         }
     }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "cy:open": "cypress open --project ./projects/demo-integrations/",
         "cy:run": "cypress run --project ./projects/demo-integrations/ --browser chrome",
         "*** Release ***": "",
-        "release": "standard-version",
+        "release": "standard-version -a --no-verify",
         "release:patch": "npm run release -- --release-as patch",
         "release:minor": "npm run release -- --release-as minor",
         "release:major": "npm run release -- --release-as major",

--- a/scripts/helpers/check-prettier-changes.ts
+++ b/scripts/helpers/check-prettier-changes.ts
@@ -1,0 +1,6 @@
+import {execute} from './execute';
+
+export function checkPrettierChanges(pattern = `**/*.{json,md}`): void {
+    execute(`prettier '${pattern}' --write`);
+    execute(`git add .`, {stdio: `inherit`});
+}

--- a/scripts/helpers/execute.ts
+++ b/scripts/helpers/execute.ts
@@ -1,0 +1,17 @@
+import {CommonExecOptions, execSync} from 'child_process';
+
+import {infoLog} from './colored-log';
+
+export function execute(shell: string, options?: Partial<CommonExecOptions>): string {
+    infoLog(`ᐅ ${shell}`);
+
+    return execSync(
+        shell,
+        options ?? {
+            stdio: `inherit`,
+            encoding: `utf8`,
+        },
+    )
+        ?.toString()
+        .trim();
+}

--- a/scripts/postchangelog.ts
+++ b/scripts/postchangelog.ts
@@ -1,0 +1,12 @@
+import {checkPrettierChanges} from './helpers/check-prettier-changes';
+
+(function main(): void {
+    /**
+     * We need to automatically format changes by prettier
+     * after the CHANGELOG is generated before commit and push
+     *
+     * postbump lifecycle script is executed just
+     * before information is written to CHANGELOG.md
+     */
+    checkPrettierChanges();
+})();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -39,5 +39,13 @@
             "@maskito/kit": ["projects/kit/src/index.ts"],
             "@demo/path": ["projects/demo/src/app/demo-path.ts"]
         }
+    },
+    "ts-node": {
+        "files": true,
+        "transpileOnly": true,
+        "compilerOptions": {
+            "types": ["node"],
+            "module": "commonjs"
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
See https://github.com/Tinkoff/maskito/pull/118
