### PR TITLE
fix(kit): `Number` pads empty integer part when paste from clipboard

### DIFF
--- a/projects/kit/src/lib/masks/number/processors/not-empty-integer-part-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/not-empty-integer-part-preprocessor.ts
@@ -11,6 +11,8 @@ export function createNotEmptyIntegerPartPreprocessor({
     decimalSeparator: string;
     precision: number;
 }): NonNullable<MaskitoOptions['preprocessor']> {
+    const startWithDecimalSepRegExp = new RegExp(`^\\D*\\${decimalSeparator}`);
+
     return ({elementState, data}) => {
         const {value, selection} = elementState;
         const [from] = selection;
@@ -18,7 +20,7 @@ export function createNotEmptyIntegerPartPreprocessor({
         if (
             precision <= 0 ||
             value.includes(decimalSeparator) ||
-            !data.startsWith(decimalSeparator)
+            !data.match(startWithDecimalSepRegExp)
         ) {
             return {elementState, data};
         }

--- a/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/not-empty-integer-part-preprocessor.spec.ts
@@ -1,0 +1,75 @@
+import {createNotEmptyIntegerPartPreprocessor} from '../not-empty-integer-part-preprocessor';
+
+const EMPTY_ELEMENT_STATE = {
+    value: '',
+    selection: [0, 0] as const,
+};
+
+describe('createNotEmptyIntegerPartPreprocessor', () => {
+    describe('precision === 2', () => {
+        const preprocessor = createNotEmptyIntegerPartPreprocessor({
+            decimalSeparator: ',',
+            precision: 2,
+        });
+
+        it('should pad integer part with zero if user inserts "a,"', () => {
+            expect(
+                preprocessor(
+                    {
+                        elementState: EMPTY_ELEMENT_STATE,
+                        data: 'a,',
+                    },
+                    'insert',
+                ),
+            ).toEqual({
+                elementState: EMPTY_ELEMENT_STATE,
+                data: '0a,',
+            });
+        });
+
+        it('should NOT pad integer part with zero if user inserts "aaa1aaa,"', () => {
+            expect(
+                preprocessor(
+                    {
+                        elementState: EMPTY_ELEMENT_STATE,
+                        data: 'aaa1aaa,',
+                    },
+                    'insert',
+                ),
+            ).toEqual({
+                elementState: EMPTY_ELEMENT_STATE,
+                data: 'aaa1aaa,',
+            });
+        });
+
+        it('should pad integer part with zero if user inserts ",3123"', () => {
+            expect(
+                preprocessor(
+                    {
+                        elementState: EMPTY_ELEMENT_STATE,
+                        data: ',3123',
+                    },
+                    'insert',
+                ),
+            ).toEqual({
+                elementState: EMPTY_ELEMENT_STATE,
+                data: '0,3123',
+            });
+        });
+
+        it('should NOT pad integer part with zero if user inserts "aaa0aaa,3123"', () => {
+            expect(
+                preprocessor(
+                    {
+                        elementState: EMPTY_ELEMENT_STATE,
+                        data: 'aaa0aaa,3123',
+                    },
+                    'insert',
+                ),
+            ).toEqual({
+                elementState: EMPTY_ELEMENT_STATE,
+                data: 'aaa0aaa,3123',
+            });
+        });
+    });
+});


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #165

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
