### PR TITLE
fix(kit): `maskitoParseNumber` incorrectly parses negative numbers

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -1,10 +1,17 @@
+import {CHAR_EM_DASH, CHAR_EN_DASH, CHAR_HYPHEN, CHAR_MINUS} from '../../../constants';
+
 export function maskitoParseNumber(
     maskedNumber: string,
     decimalSeparator: string = '.',
 ): number {
+    const negativeSign = maskedNumber.match(
+        new RegExp(`^[${CHAR_MINUS}\\${CHAR_HYPHEN}${CHAR_EN_DASH}${CHAR_EM_DASH}]`),
+    );
+
     return Number(
-        maskedNumber
-            .replace(new RegExp(`[^\\d\\${decimalSeparator}]`, 'g'), '')
-            .replace(decimalSeparator, '.'),
+        (negativeSign ? CHAR_HYPHEN : '') +
+            maskedNumber
+                .replace(new RegExp(`[^\\d\\${decimalSeparator}]`, 'g'), '')
+                .replace(decimalSeparator, '.'),
     );
 }

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -1,3 +1,4 @@
+import {CHAR_EM_DASH, CHAR_EN_DASH, CHAR_HYPHEN, CHAR_MINUS} from '../../../../constants';
 import {maskitoParseNumber} from '../parse-number';
 
 describe('maskitoParseNumber', () => {
@@ -34,6 +35,34 @@ describe('maskitoParseNumber', () => {
 
         it('empty decimal part & thousand separator is dot', () => {
             expect(maskitoParseNumber('42.111', ',')).toBe(42111);
+        });
+    });
+
+    describe('negative numbers', () => {
+        describe('minus sign', () => {
+            it('can be minus', () => {
+                expect(maskitoParseNumber(`${CHAR_MINUS}1`)).toBe(-1);
+            });
+
+            it('can be hyphen', () => {
+                expect(maskitoParseNumber(`${CHAR_HYPHEN}123 456`)).toBe(-123456);
+            });
+
+            it('can be en-dash', () => {
+                expect(maskitoParseNumber(`${CHAR_EN_DASH}123 456 789`)).toBe(-123456789);
+            });
+
+            it('can be em-dash', () => {
+                expect(maskitoParseNumber(`${CHAR_EM_DASH}42`)).toBe(-42);
+            });
+        });
+
+        it('parses negative integer number when thousand separator is hyphen & minus sign is hyphen', () => {
+            expect(maskitoParseNumber('-123-456')).toBe(-123456);
+        });
+
+        it('parses negative number with decimal part', () => {
+            expect(maskitoParseNumber('-123.456')).toBe(-123.456);
         });
     });
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #188

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
