### PR TITLE
fix(angular): use `@nrwl/angular:package` executor instead of `@nrwl/angular:ng-packagr-lite`

### DIFF
--- a/projects/angular/project.json
+++ b/projects/angular/project.json
@@ -5,7 +5,7 @@
     "prefix": "maskito",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
+            "executor": "@nrwl/angular:package",
             "outputs": ["dist/angular"],
             "options": {
                 "project": "projects/angular/ng-package.json"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## Why?
`@nrwl/angular:ng-packagr-lite` executors is for **BUILDABLE** libraries and the `@nrwl/angular:package` executor is for **PUBLISHABLE** libraries.

Read more:
* https://github.com/nrwl/nx/issues/9727#issuecomment-1091926084
* https://nx.dev/packages/angular/executors/ng-packagr-lite
* https://nx.dev/packages/angular/executors/package


