### PR TITLE
fix(kit): `Number` fails to trim leading zeroes after deleting of leading digit

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/number/number-zero-integer-part.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-zero-integer-part.cy.ts
@@ -88,9 +88,7 @@ describe('Number | Zero integer part', () => {
                 .should('have.prop', 'selectionEnd', '0'.length);
         });
 
-        // TODO: BUG!
-        // https://github.com/Tinkoff/maskito/issues/266
-        it.skip('1|-000-000 => Backspace => 0', () => {
+        it('1|-000-000 => Backspace => 0', () => {
             openNumberPage('thousandSeparator=_&precision=2');
 
             cy.get('@input')

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -72,7 +72,10 @@ export function maskitoNumberOptionsGenerator({
             createZeroPrecisionPreprocessor(precision, decimalSeparator),
         ),
         postprocessor: maskitoPipe(
-            createLeadingZeroesValidationPostprocessor(decimalSeparator),
+            createLeadingZeroesValidationPostprocessor(
+                decimalSeparator,
+                thousandSeparator,
+            ),
             createMaxValidationPostprocessor({decimalSeparator, max}),
             maskitoPrefixPostprocessorGenerator(prefix),
             maskitoPostfixPostprocessorGenerator(postfix),

--- a/projects/kit/src/lib/masks/number/processors/leading-zeroes-validation-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/leading-zeroes-validation-postprocessor.ts
@@ -14,15 +14,17 @@ export function createLeadingZeroesValidationPostprocessor(
     thousandSeparator: string,
 ): NonNullable<MaskitoOptions['postprocessor']> {
     const trimLeadingZeroes = (value: string): string => {
+        const escapedThousandSeparator = escapeRegExp(thousandSeparator);
+
         return value
             .replace(
                 // all leading zeroes followed by another zero
-                new RegExp(`^(\\D+)?[0${escapeRegExp(thousandSeparator)}]+(?=0)`),
+                new RegExp(`^(\\D+)?[0${escapedThousandSeparator}]+(?=0)`),
                 '$1',
             )
             .replace(
                 // zero followed by not-zero digit
-                new RegExp(`^(\\D+)?[0${escapeRegExp(thousandSeparator)}]+(?=[1-9])`),
+                new RegExp(`^(\\D+)?[0${escapedThousandSeparator}]+(?=[1-9])`),
                 '$1',
             );
     };

--- a/projects/kit/src/lib/masks/number/processors/leading-zeroes-validation-postprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/leading-zeroes-validation-postprocessor.ts
@@ -1,5 +1,7 @@
 import {MaskitoOptions} from '@maskito/core';
 
+import {escapeRegExp} from '../../../utils';
+
 /**
  * It removes repeated leading zeroes for integer part.
  * @example 0,|00005 => Backspace => |5
@@ -9,7 +11,33 @@ import {MaskitoOptions} from '@maskito/core';
  */
 export function createLeadingZeroesValidationPostprocessor(
     decimalSeparator: string,
+    thousandSeparator: string,
 ): NonNullable<MaskitoOptions['postprocessor']> {
+    const trimLeadingZeroes = (value: string): string => {
+        return value
+            .replace(
+                // all leading zeroes followed by another zero
+                new RegExp(`^(\\D+)?[0${escapeRegExp(thousandSeparator)}]+(?=0)`),
+                '$1',
+            )
+            .replace(
+                // zero followed by not-zero digit
+                new RegExp(`^(\\D+)?[0${escapeRegExp(thousandSeparator)}]+(?=[1-9])`),
+                '$1',
+            );
+    };
+
+    const countTrimmedZeroesBefore = (value: string, index: number): number => {
+        const valueBefore = value.slice(0, index);
+        const followedByZero = value.slice(index).startsWith('0');
+
+        return (
+            valueBefore.length -
+            trimLeadingZeroes(valueBefore).length +
+            (followedByZero ? 1 : 0)
+        );
+    };
+
     return ({value, selection}) => {
         const [from, to] = selection;
         const hasDecimalSeparator = value.includes(decimalSeparator);
@@ -31,21 +59,4 @@ export function createLeadingZeroesValidationPostprocessor(
             selection: [Math.max(newFrom, 0), Math.max(newTo, 0)],
         };
     };
-}
-
-function trimLeadingZeroes(value: string): string {
-    return value
-        .replace(/^(\D+)?0+(?=0)/, '$1') // all leading zeroes followed by another zero
-        .replace(/^(\D+)?0+(?=[1-9])/, '$1'); // zero followed by not-zero digit
-}
-
-function countTrimmedZeroesBefore(value: string, index: number): number {
-    const valueBefore = value.slice(0, index);
-    const followedByZero = value.slice(index).startsWith('0');
-
-    return (
-        valueBefore.length -
-        trimLeadingZeroes(valueBefore).length +
-        (followedByZero ? 1 : 0)
-    );
 }

--- a/projects/kit/src/lib/masks/number/processors/tests/leading-zeroes-validation-postprocessor.spec.ts
+++ b/projects/kit/src/lib/masks/number/processors/tests/leading-zeroes-validation-postprocessor.spec.ts
@@ -1,7 +1,7 @@
 import {createLeadingZeroesValidationPostprocessor} from '../leading-zeroes-validation-postprocessor';
 
 describe('createLeadingZeroesValidationPostprocessor', () => {
-    const processor = createLeadingZeroesValidationPostprocessor(',');
+    const processor = createLeadingZeroesValidationPostprocessor(',', '');
     const DYMMY_INITIAL_STATE = {value: '', selection: [0, 0]} as const;
 
     const process = (


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #266

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
