### PR TITLE
docs(demo): correct pin code mask expression

### DIFF
--- a/projects/demo/src/pages/documentation/mask-expression/mask-expression.template.html
+++ b/projects/demo/src/pages/documentation/mask-expression/mask-expression.template.html
@@ -57,14 +57,14 @@
                     </p>
 
                     <p>
-                        <code>{{ '/^\d{4}$/' }}</code>
+                        <code>{{ '/^\\d{4}$/' }}</code>
                         is a wrong mask expression. It does not match
                         intermediate states (you cannot complete 4-digit string
                         without possibility to type 1-, 2- or 3-digit string).
                     </p>
 
                     <p>
-                        <code>{{ '/^\d{0,4}$/' }}</code>
+                        <code>{{ '/^\\d{0,4}$/' }}</code>
                         is the right solution for our example.
                     </p>
                 </tui-notification>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [x] Documentation content changes

## What is the current behavior?

The PIN code [mask expression docs](https://tinkoff.github.io/maskito/core-concepts/mask-expression) experiences a formatting issue where the `\` is removed from the final examples.

e.g.: The docs show `/^d{4}$/` but the expected value is `/^\d{4}$/`. 

## What is the new behavior?

Updates both the `/^\d{4}$/` and `/^\d{0,4}$/` mask expression examples for the PIN code to include the backslash for the regular expression.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
