### PR TITLE
ci(react): make `nx build react` to depend on `nx build core`

### DIFF
--- a/projects/react/project.json
+++ b/projects/react/project.json
@@ -21,7 +21,14 @@
                         "output": "."
                     }
                 ]
-            }
+            },
+            "dependsOn": [
+                {
+                    "target": "build",
+                    "projects": "dependencies",
+                    "params": "forward"
+                }
+            ]
         },
         "lint": {
             "executor": "@nrwl/linter:eslint",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
```
➜ nx build react          

> nx run react:build 
Some of the project react's dependencies have not been built yet. Please build these libraries before:
- core
```

## What is the new behavior?
```
➜ nx build react

>  NX  Running target build for project react and 1 task(s) that it depends on.
        

———————————————————————————————————————————————

> nx run core:build 
Bundling core...
  index.esm.js 21.514 KB
  index.umd.js 30.322 KB
⚡ Done in 4.44s

> nx run react:build 
Bundling react...
  index.esm.js 1.482 KB
No name was provided for external module '@maskito/core' in output.globals – guessing 'core'
  index.umd.js 2.29 KB
⚡ Done in 3.31s

———————————————————————————————————————————————

>  NX   SUCCESS  Running target "build" succeeded
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
