### PR TITLE
chore(demo): add Node.js 18 support

### DIFF
--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node.js version
     required: false
-    default: 16.x
+    default: 18.15
 
 runs:
   using: composite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,19 +18,19 @@ jobs:
       - name: Run tests
         run: npx nx run-many --target test --all --coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           directory: ./coverage/core/
           flags: summary,core
           name: core
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           directory: ./coverage/kit/
           flags: summary,kit
           name: kit
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           directory: ./coverage/angular/
           flags: summary,angular

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,8 +63,8 @@
                 "typescript": "~4.3.5"
             },
             "engines": {
-                "node": ">= 16.14",
-                "npm": ">= 8.3",
+                "node": ">= 18",
+                "npm": ">= 9",
                 "yarn": "Please use npm instead of yarn to install dependencies"
             }
         },
@@ -6261,6 +6261,18 @@
                 "node": ">=10.10.0"
             }
         },
+        "node_modules/@nrwl/js/node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@nrwl/js/node_modules/@nrwl/cli": {
             "version": "13.3.0",
             "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-13.3.0.tgz",
@@ -6666,6 +6678,18 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/@nrwl/js/node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@nrwl/js/node_modules/eslint/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -6751,6 +6775,18 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@nrwl/js/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
@@ -7014,6 +7050,18 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@nrwl/linter/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
@@ -7969,6 +8017,18 @@
             },
             "engines": {
                 "node": ">=10.10.0"
+            }
+        },
+        "node_modules/@nrwl/react/node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@nrwl/react/node_modules/@nrwl/cli": {
@@ -8960,6 +9020,18 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/@nrwl/react/node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@nrwl/react/node_modules/eslint/node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -9045,6 +9117,18 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@nrwl/react/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
@@ -10792,6 +10876,18 @@
                 "node": ">=10.10.0"
             }
         },
+        "node_modules/@nrwl/web/node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@nrwl/web/node_modules/@nrwl/cli": {
             "version": "13.4.2",
             "resolved": "https://registry.npmjs.org/@nrwl/cli/-/cli-13.4.2.tgz",
@@ -10923,6 +11019,18 @@
                 "node": "*"
             }
         },
+        "node_modules/@nrwl/web/node_modules/@nrwl/linter/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@nrwl/web/node_modules/@nrwl/tao": {
             "version": "13.4.2",
             "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-13.4.2.tgz",
@@ -11000,6 +11108,18 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@nrwl/web/node_modules/@nrwl/workspace/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
@@ -11730,6 +11850,18 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@nrwl/web/node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@nrwl/web/node_modules/eslint/node_modules/strip-ansi": {
@@ -13048,6 +13180,18 @@
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@nrwl/workspace/node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
                 "node": "*"
@@ -48723,6 +48867,17 @@
                         "@humanwhocodes/object-schema": "^1.2.0",
                         "debug": "^4.1.1",
                         "minimatch": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "@nrwl/cli": {
@@ -49025,6 +49180,15 @@
                                 "argparse": "^2.0.1"
                             }
                         },
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
                         "strip-ansi": {
                             "version": "6.0.1",
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -49110,6 +49274,17 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "globals": {
@@ -49311,6 +49486,17 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 }
             }
@@ -50097,6 +50283,17 @@
                         "@humanwhocodes/object-schema": "^1.2.0",
                         "debug": "^4.1.1",
                         "minimatch": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "@nrwl/cli": {
@@ -50902,6 +51099,15 @@
                                 "argparse": "^2.0.1"
                             }
                         },
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
                         "strip-ansi": {
                             "version": "6.0.1",
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -50977,6 +51183,17 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "globals": {
@@ -52263,6 +52480,17 @@
                         "@humanwhocodes/object-schema": "^1.2.0",
                         "debug": "^4.1.1",
                         "minimatch": "^3.0.4"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "@nrwl/cli": {
@@ -52380,6 +52608,17 @@
                                 "minimatch": "^3.0.4",
                                 "once": "^1.3.0",
                                 "path-is-absolute": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "minimatch": {
+                                    "version": "3.1.2",
+                                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                                    "dev": true,
+                                    "requires": {
+                                        "brace-expansion": "^1.1.7"
+                                    }
+                                }
                             }
                         }
                     }
@@ -52450,6 +52689,17 @@
                                 "minimatch": "^3.0.4",
                                 "once": "^1.3.0",
                                 "path-is-absolute": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "minimatch": {
+                                    "version": "3.1.2",
+                                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                                    "dev": true,
+                                    "requires": {
+                                        "brace-expansion": "^1.1.7"
+                                    }
+                                }
                             }
                         }
                     }
@@ -52992,6 +53242,15 @@
                             "dev": true,
                             "requires": {
                                 "argparse": "^2.0.1"
+                            }
+                        },
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
                             }
                         },
                         "strip-ansi": {
@@ -53918,6 +54177,17 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
                     }
                 },
                 "has-flag": {

--- a/package.json
+++ b/package.json
@@ -122,8 +122,8 @@
         "typescript": "~4.3.5"
     },
     "engines": {
-        "node": ">= 16.14",
-        "npm": ">= 8.3",
+        "node": ">= 18",
+        "npm": ">= 9",
         "yarn": "Please use npm instead of yarn to install dependencies"
     },
     "standard-version": {

--- a/projects/demo/src/app/server-error-handler.ts
+++ b/projects/demo/src/app/server-error-handler.ts
@@ -4,12 +4,13 @@ import {hasFlag} from 'scripts/helpers/argv';
 // TODO
 const KNOWN_ISSUES: string[] = [
     'requestAnimationFrame is not defined', // hljs
+    'TypeError: Failed to parse URL from assets', // https://github.com/Tinkoff/taiga-ui/issues/4063
 ];
 
 @Injectable()
 export class ServerErrorHandler implements ErrorHandler {
     handleError(error: Error): void {
-        if (KNOWN_ISSUES.includes(error.message)) {
+        if (KNOWN_ISSUES.some(issue => error.message.includes(issue))) {
             return;
         }
 

--- a/projects/demo/webpack.config.ts
+++ b/projects/demo/webpack.config.ts
@@ -22,6 +22,33 @@ const RAW_QUERY = /raw/;
  */
 const DONT_MUTATE_RAW_FILE_CONTENTS = [`*.ts`, `*.less`, `*.html`, `*.css`];
 
+/**
+ * [Fixed bug in Node.js 18]
+ * error:0308010C:digital envelope routines::unsupported
+ *
+ * TODO: after upgrading of angular/nx deps run `npm audit fix` and drop this temporary workaround
+ * Learn more: https://stackoverflow.com/a/73027407
+ *
+ * https://github.com/webpack/webpack/issues/13572#issuecomment-923736472
+ * Useful when needing to revert to a legacy algorithm
+ * (OpenSSL / potentially less secure one) to temporarily
+ * address any compatibility issues.
+ *
+ * output.hashFunction doesn't work now,
+ * upgrade @angular-devkit/build-angular to v14 and use
+ *
+ * output: {
+ *   hashFunction: `xxhash64`,
+ * },
+ *
+ * instead of:
+ */
+const crypto = require(`crypto`);
+const fallbackCreateHash = crypto.createHash;
+
+crypto.createHash = (algorithm: string) =>
+    fallbackCreateHash(algorithm === `md4` ? `sha256` : algorithm);
+
 const config: Configuration = {
     module: {
         /**


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [X] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
```
nvm use 18.15
npm start
```

it throws
```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory 
    [...]
```

## What is the new behavior?
Repository is compatible with Node.js 18

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
