### PR TITLE
fix(core): a layout-independent way to detect undo and redo shortcuts

### DIFF
--- a/projects/core/src/lib/mask.ts
+++ b/projects/core/src/lib/mask.ts
@@ -11,6 +11,7 @@ import {
     isEventProducingCharacter,
     maskitoTransform,
 } from './utils';
+import {isRedo, isUndo} from './utils/dom/history-events';
 
 export class Maskito extends MaskHistory {
     private readonly isTextArea = this.element.nodeName === 'TEXTAREA';
@@ -33,15 +34,13 @@ export class Maskito extends MaskHistory {
         this.updateHistory(this.elementState);
 
         this.eventListener.listen('keydown', event => {
-            const {ctrlKey, key, metaKey, shiftKey} = event;
-
-            if ((metaKey && shiftKey && key === 'z') || (ctrlKey && key === 'y')) {
+            if (isRedo(event)) {
                 event.preventDefault();
 
                 return this.redo();
             }
 
-            if ((ctrlKey || metaKey) && key === 'z') {
+            if (isUndo(event)) {
                 event.preventDefault();
 
                 return this.undo();

--- a/projects/core/src/lib/utils/dom/history-events.ts
+++ b/projects/core/src/lib/utils/dom/history-events.ts
@@ -1,0 +1,14 @@
+export function isRedo({ctrlKey, metaKey, shiftKey, code}: KeyboardEvent): boolean {
+    return (
+        (ctrlKey && code === 'KeyY') || // Windows
+        (ctrlKey && shiftKey && code === 'KeyZ') || // Windows & Android
+        (metaKey && shiftKey && code === 'KeyZ') // macOS & iOS
+    );
+}
+
+export function isUndo({ctrlKey, metaKey, code}: KeyboardEvent): boolean {
+    return (
+        (ctrlKey && code === 'KeyZ') || // Windows & Android
+        (metaKey && code === 'KeyZ') // macOS & iOS
+    );
+}


### PR DESCRIPTION
A more reliable way to determine the pressed key is used (using [KeyboardEvent#code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code)).

Also added handling of `Ctrl` + `Shift` + `Z` on Windows.

Closes: #310