### PR TITLE
ci: drop extra peer dependency from `@maskito/vue` build

### DIFF
--- a/projects/vue/src/lib/maskito.spec.ts
+++ b/projects/vue/src/lib/maskito.spec.ts
@@ -1,18 +1,28 @@
-import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 import {maskito} from '@maskito/vue';
 import {mount} from '@vue/test-utils';
 
 describe('Maskito Vue package', () => {
+    const options = {
+        mask: [
+            ...Array(4).fill(/\d/),
+            ' ',
+            ...Array(4).fill(/\d/),
+            ' ',
+            ...Array(4).fill(/\d/),
+            ' ',
+            ...Array(4).fill(/\d/),
+        ],
+    };
     const component = {
         template: '<input v-model="value" v-maskito="options" />',
         directives: {maskito},
         data: () => ({
-            value: '1234567',
-            options: maskitoNumberOptionsGenerator(),
+            value: '1234567890123456',
+            options: options,
         }),
     };
 
     test('formats text', () => {
-        expect(mount(component).find('input').element.value).toBe(`1\u00A0234\u00A0567`);
+        expect(mount(component).find('input').element.value).toBe(`1234 5678 9012 3456`);
     });
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- [X] Build or CI related changes

## What is the current behavior?
1. Run `nx build vue`
2. See `dist/vue/package.json`

It contains:
```json
"peerDependencies": {
    "@maskito/core": "^0.12.1",
    "vue": ">=3.0.0",
    "@maskito/kit": "0.12.1"
  },
```

## What is the new behavior?
`dist/vue/package.json` contains only

```json
"peerDependencies": {
    "@maskito/core": "^0.12.1",
    "vue": ">=3.0.0"
  },
```