### PR TITLE
fix(kit): `maskitoParseNumber` should return `NaN` for all strings with no digits

### DIFF
--- a/projects/kit/src/lib/masks/number/utils/parse-number.ts
+++ b/projects/kit/src/lib/masks/number/utils/parse-number.ts
@@ -8,11 +8,11 @@ export function maskitoParseNumber(
     const negativeSign = maskedNumber.match(
         new RegExp(`^[${CHAR_MINUS}\\${CHAR_HYPHEN}${CHAR_EN_DASH}${CHAR_EM_DASH}]`),
     );
+    const unmaskedNumber = maskedNumber
+        .replace(new RegExp(`[^\\d${escapeRegExp(decimalSeparator)}]`, 'g'), '')
+        .replace(decimalSeparator, '.');
 
-    return Number(
-        (negativeSign ? CHAR_HYPHEN : '') +
-            maskedNumber
-                .replace(new RegExp(`[^\\d${escapeRegExp(decimalSeparator)}]`, 'g'), '')
-                .replace(decimalSeparator, '.'),
-    );
+    return unmaskedNumber
+        ? Number((negativeSign ? CHAR_HYPHEN : '') + unmaskedNumber)
+        : NaN;
 }

--- a/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
+++ b/projects/kit/src/lib/masks/number/utils/tests/parse-number.spec.ts
@@ -18,6 +18,10 @@ describe('maskitoParseNumber', () => {
         it('empty decimal part & thousand separator is comma', () => {
             expect(maskitoParseNumber('1,000,000')).toBe(1000000);
         });
+
+        it('trailing decimal separator', () => {
+            expect(maskitoParseNumber('0.')).toBe(0);
+        });
     });
 
     describe('decimal separator is comma', () => {
@@ -35,6 +39,10 @@ describe('maskitoParseNumber', () => {
 
         it('empty decimal part & thousand separator is dot', () => {
             expect(maskitoParseNumber('42.111', ',')).toBe(42111);
+        });
+
+        it('trailing decimal separator', () => {
+            expect(maskitoParseNumber('42,', ',')).toBe(42);
         });
     });
 
@@ -77,6 +85,24 @@ describe('maskitoParseNumber', () => {
 
         it('parses number with both prefix and postfix', () => {
             expect(maskitoParseNumber('$42 per day')).toBe(42);
+        });
+    });
+
+    describe('NaN', () => {
+        it('Empty string => NaN', () => {
+            expect(maskitoParseNumber('')).toBeNaN();
+        });
+
+        it('Decimal separator only => NaN', () => {
+            expect(maskitoParseNumber('.')).toBeNaN();
+            expect(maskitoParseNumber(',', ',')).toBeNaN();
+        });
+
+        it('Negative sign only => NaN', () => {
+            expect(maskitoParseNumber('\u2212')).toBeNaN(); // minus
+            expect(maskitoParseNumber('-')).toBeNaN();
+            expect(maskitoParseNumber('\u2013')).toBeNaN(); // en-dash
+            expect(maskitoParseNumber('\u2014')).toBeNaN(); // em-dash
         });
     });
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes
