### PR TITLE
feat(kit)!: delete deprecated `isNegativeAllowed` parameter from `Number` mask

### DIFF
--- a/projects/demo/src/pages/kit/number/number-mask-doc.component.ts
+++ b/projects/demo/src/pages/kit/number/number-mask-doc.component.ts
@@ -72,13 +72,6 @@ export class NumberMaskDocComponent implements GeneratorOptions {
 
     maskitoOptions: MaskitoOptions = maskitoNumberOptionsGenerator(this);
 
-    /**
-     * TODO: drop in 1.x.x
-     */
-    get isNegativeAllowed(): boolean {
-        return this.min < 0;
-    }
-
     updateOptions(): void {
         this.maskitoOptions = maskitoNumberOptionsGenerator(this);
     }

--- a/projects/demo/src/pages/kit/number/number-mask-doc.template.html
+++ b/projects/demo/src/pages/kit/number/number-mask-doc.template.html
@@ -289,21 +289,6 @@
                     empty string (no postfix).
                 </p>
             </ng-template>
-            <ng-template
-                documentationPropertyName="isNegativeAllowed"
-                documentationPropertyMode="input"
-                [documentationPropertyDeprecated]="true"
-            >
-                Allows to input negative sign (minus).
-
-                <p>
-                    <strong>
-                        Use
-                        <code>min >= 0</code>
-                        to disable negative numbers.
-                    </strong>
-                </p>
-            </ng-template>
         </tui-doc-documentation>
     </ng-template>
 </tui-doc-page>

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -27,7 +27,6 @@ import {generateMaskExpression, getDefaultPseudoSeparators} from './utils';
 export function maskitoNumberOptionsGenerator({
     max = Number.MAX_SAFE_INTEGER,
     min = Number.MIN_SAFE_INTEGER,
-    isNegativeAllowed = min < 0,
     precision = 0,
     thousandSeparator = CHAR_NO_BREAK_SPACE,
     decimalSeparator = '.',
@@ -41,11 +40,6 @@ export function maskitoNumberOptionsGenerator({
 }: {
     min?: number;
     max?: number;
-    /**
-     * @deprecated use `min > 0` instead of `isNegativeAllowed: false`
-     * TODO: delete in 1.x.x
-     */
-    isNegativeAllowed?: boolean;
     precision?: number;
     decimalSeparator?: string;
     decimalPseudoSeparators?: string[];
@@ -64,9 +58,9 @@ export function maskitoNumberOptionsGenerator({
             decimalSeparator,
             precision,
             thousandSeparator,
-            isNegativeAllowed,
             prefix,
             postfix,
+            isNegativeAllowed: min < 0,
         }),
         preprocessors: [
             createPseudoCharactersPreprocessor(CHAR_MINUS, pseudoMinuses),


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
```ts
import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 
const options = maskitoNumberOptionsGenerator({
    isNegativeAllowed: false,
});
```

## What is the new behavior?
```ts
import {maskitoNumberOptionsGenerator} from '@maskito/kit';
 
const options = maskitoNumberOptionsGenerator({
    min: 0,
});
```

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No
