### PR TITLE
fix(kit): `Number` should ignore new typed decimal separator if it already exists in text field

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/number/number-decimal-separator.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-decimal-separator.cy.ts
@@ -1,3 +1,4 @@
+import {BROWSER_SUPPORTS_REAL_EVENTS} from '../../../support/constants';
 import {openNumberPage} from './utils';
 
 describe('Number | Decimal separator (symbol used to separate the integer part from the fractional part)', () => {
@@ -81,15 +82,13 @@ describe('Number | Decimal separator (symbol used to separate the integer part f
 
     describe('Decimal separator is a dot', () => {
         beforeEach(() => {
-            openNumberPage(
-                'decimalSeparator=.&precision=2&decimalZeroPadding=true&decimalPseudoSeparators$=2',
-            );
+            openNumberPage('decimalSeparator=.&precision=2&decimalPseudoSeparators$=2');
         });
 
         it('accepts dot (as the last character)', () => {
             cy.get('@input')
                 .type('123.')
-                .should('have.value', '123.00')
+                .should('have.value', '123.')
                 .should('have.prop', 'selectionStart', '123.'.length)
                 .should('have.prop', 'selectionEnd', '123.'.length);
         });
@@ -99,7 +98,7 @@ describe('Number | Decimal separator (symbol used to separate the integer part f
                 .type('42')
                 .type('{leftArrow}')
                 .type('.')
-                .should('have.value', '4.20')
+                .should('have.value', '4.2')
                 .should('have.prop', 'selectionStart', '4.'.length)
                 .should('have.prop', 'selectionEnd', '4.'.length);
         });
@@ -107,7 +106,7 @@ describe('Number | Decimal separator (symbol used to separate the integer part f
         it('accepts comma (as the last character) and transforms it to dot', () => {
             cy.get('@input')
                 .type('123,')
-                .should('have.value', '123.00')
+                .should('have.value', '123.')
                 .should('have.prop', 'selectionStart', '123.'.length)
                 .should('have.prop', 'selectionEnd', '123.'.length);
         });
@@ -117,7 +116,7 @@ describe('Number | Decimal separator (symbol used to separate the integer part f
                 .type('42')
                 .type('{leftArrow}')
                 .type(',')
-                .should('have.value', '4.20')
+                .should('have.value', '4.2')
                 .should('have.prop', 'selectionStart', '4.'.length)
                 .should('have.prop', 'selectionEnd', '4.'.length);
         });
@@ -127,7 +126,53 @@ describe('Number | Decimal separator (symbol used to separate the integer part f
                 .type('123')
                 .type('{moveToStart}{rightArrow}')
                 .type('F')
-                .should('have.value', '123.00');
+                .should('have.value', '123');
         });
+    });
+
+    describe('Attempt to enter decimal separator when it already exists in text field', () => {
+        beforeEach(() => {
+            openNumberPage('decimalSeparator=,&thousandSeparator=_&precision=2');
+        });
+
+        it('1|23,45 => Press comma (decimal separator) => 1|23,45 (no changes)', () => {
+            cy.get('@input')
+                .type('123,45')
+                .type('{moveToStart}{rightArrow}')
+                .type(',')
+                .should('have.value', '123,45')
+                .should('have.prop', 'selectionStart', '1'.length)
+                .should('have.prop', 'selectionEnd', '1'.length);
+        });
+
+        it('1|23,45 => Press point (pseudo decimal separator) => 1|23,45 (no changes)', () => {
+            cy.get('@input')
+                .type('123.45')
+                .type('{moveToStart}{rightArrow}')
+                .type('.')
+                .should('have.value', '123,45')
+                .should('have.prop', 'selectionStart', '1'.length)
+                .should('have.prop', 'selectionEnd', '1'.length);
+        });
+
+        it(
+            '1|23,4|5 => Type decimal separator => 1,5',
+            BROWSER_SUPPORTS_REAL_EVENTS,
+            () => {
+                cy.get('@input')
+                    .type('123,45')
+                    .realPress([
+                        'ArrowLeft',
+                        'Shift',
+                        ...Array('23,4'.length).fill('ArrowLeft'),
+                    ]);
+
+                cy.get('@input')
+                    .type(',')
+                    .should('have.value', '1,5')
+                    .should('have.prop', 'selectionStart', '1,'.length)
+                    .should('have.prop', 'selectionEnd', '1,'.length);
+            },
+        );
     });
 });

--- a/projects/demo-integrations/cypress/tests/kit/number/number-decimal-zero-padding.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-decimal-zero-padding.cy.ts
@@ -128,7 +128,7 @@ describe('Number | decimalZeroPadding', () => {
                 .should('have.prop', 'selectionEnd', '42,2'.length);
         });
 
-        it('9|9,1234 => Type , => 9,|9123', () => {
+        it('9|9,1234 => Type , => 9|9,1234 (no changes)', () => {
             cy.get('@input')
                 .type('99,1234')
                 .type('{moveToStart}{rightArrow}')
@@ -136,9 +136,9 @@ describe('Number | decimalZeroPadding', () => {
                 .should('have.prop', 'selectionStart', 1)
                 .should('have.prop', 'selectionEnd', 1)
                 .type(',')
-                .should('have.value', '9,9123')
-                .should('have.prop', 'selectionStart', 2)
-                .should('have.prop', 'selectionEnd', 2);
+                .should('have.value', '99,1234')
+                .should('have.prop', 'selectionStart', 1)
+                .should('have.prop', 'selectionEnd', 1);
         });
     });
 

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -19,6 +19,7 @@ import {
     createNonRemovableCharsDeletionPreprocessor,
     createNotEmptyIntegerPartPreprocessor,
     createPseudoCharactersPreprocessor,
+    createRepeatedDecimalSeparatorPreprocessor,
     createThousandSeparatorPostprocessor,
     createZeroPrecisionPreprocessor,
 } from './processors';
@@ -72,6 +73,7 @@ export function maskitoNumberOptionsGenerator({
                 thousandSeparator,
             }),
             createZeroPrecisionPreprocessor(precision, decimalSeparator),
+            createRepeatedDecimalSeparatorPreprocessor(decimalSeparator),
         ],
         postprocessors: [
             createLeadingZeroesValidationPostprocessor(

--- a/projects/kit/src/lib/masks/number/processors/index.ts
+++ b/projects/kit/src/lib/masks/number/processors/index.ts
@@ -4,5 +4,6 @@ export * from './min-max-postprocessor';
 export * from './non-removable-chars-deletion-preprocessor';
 export * from './not-empty-integer-part-preprocessor';
 export * from './preudo-character-preprocessor';
+export * from './repeated-decimal-separator-preprocessor';
 export * from './thousand-separator-postprocessor';
 export * from './zero-precision-preprocessor';

--- a/projects/kit/src/lib/masks/number/processors/repeated-decimal-separator-preprocessor.ts
+++ b/projects/kit/src/lib/masks/number/processors/repeated-decimal-separator-preprocessor.ts
@@ -1,0 +1,26 @@
+import {MaskitoPreprocessor} from '@maskito/core';
+
+import {escapeRegExp} from '../../../utils';
+
+/**
+ * It rejects new typed decimal separator if it already exists in text field.
+ * Behaviour is similar to native <input type="number"> (Chrome).
+ * @example 1|23,45 => Press comma (decimal separator) => 1|23,45 (do nothing).
+ */
+export function createRepeatedDecimalSeparatorPreprocessor(
+    decimalSeparator: string,
+): MaskitoPreprocessor {
+    return ({elementState, data}) => {
+        const {value, selection} = elementState;
+        const [from, to] = selection;
+
+        return {
+            elementState,
+            data:
+                !value.includes(decimalSeparator) ||
+                value.slice(from, to + 1).includes(decimalSeparator)
+                    ? data
+                    : data.replace(new RegExp(escapeRegExp(decimalSeparator), 'gi'), ''),
+        };
+    };
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #330

## What is the new behavior?
Behaviour is similar to native [<input type="number">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) (Chrome).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
