### PR TITLE
fix(kit): `Number` should skip min/max validation if value does not contain any digits

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/number/number-examples.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-examples.cy.ts
@@ -1,0 +1,24 @@
+import {DemoPath} from '@demo/constants';
+
+describe('Documentation page "Number"', () => {
+    beforeEach(() => {
+        cy.visit(DemoPath.Number);
+    });
+
+    describe('Example "Postfix"', () => {
+        beforeEach(() => {
+            cy.get('#postfix input').should('be.visible').first().as('input');
+        });
+
+        it('pads value without digits with zero on blur', () => {
+            cy.get('@input')
+                .focus()
+                .should('have.prop', 'selectionStart', '97'.length)
+                .should('have.prop', 'selectionEnd', '97'.length)
+                .clear()
+                .should('have.value', '%')
+                .blur()
+                .should('have.value', '0%');
+        });
+    });
+});

--- a/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/min-max.plugin.ts
@@ -23,7 +23,7 @@ export function createMinMaxPlugin({
             const parsedNumber = maskitoParseNumber(element.value, decimalSeparator);
             const clampedNumber = clamp(parsedNumber, min, max);
 
-            if (parsedNumber !== clampedNumber) {
+            if (!Number.isNaN(parsedNumber) && parsedNumber !== clampedNumber) {
                 element.value = maskitoTransform(
                     stringifyNumberWithoutExp(clampedNumber),
                     options,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?
1. Open https://tinkoff.github.io/maskito/kit/number#postfix
2. `Ctrl` + `A` (select all) + Press `Backspace`
3. Blur

**Expected**: `0%`.
**Actual**: ``.
