### PR TITLE
fix(kit): `Number` should remove repeated leading zeroes for integer part only on `blur`-event

### DIFF
--- a/projects/demo-integrations/cypress/tests/kit/number/number-prefix-postfix.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-prefix-postfix.cy.ts
@@ -91,35 +91,41 @@ describe('Number | Prefix & Postfix', () => {
                 .should('have.prop', 'selectionEnd', '$0.12'.length);
         });
 
-        describe('it removes repeated leading zeroes for integer part', () => {
-            it('Type 000000 => $0| per day', () => {
+        describe('it removes repeated leading zeroes for integer part on blur', () => {
+            it('Type 000000 => blur => $0| per day', () => {
                 cy.get('@input')
                     .type('000000')
-                    .should('have.value', '$0 per day')
-                    .should('have.prop', 'selectionStart', '$0'.length)
-                    .should('have.prop', 'selectionEnd', '$0'.length);
+                    .should('have.value', '$000_000 per day')
+                    .should('have.prop', 'selectionStart', '$000_000'.length)
+                    .should('have.prop', 'selectionEnd', '$000_000'.length)
+                    .blur()
+                    .should('have.value', '$0 per day');
             });
 
-            it('$0| per day => Type 5 => $5| per day', () => {
+            it('$0| per day => Type 5 => blur => $5| per day', () => {
                 cy.get('@input')
                     .type('0')
                     .should('have.value', '$0 per day')
                     .should('have.prop', 'selectionStart', '$0'.length)
                     .should('have.prop', 'selectionEnd', '$0'.length)
                     .type('5')
-                    .should('have.value', '$5 per day')
-                    .should('have.prop', 'selectionStart', '$5'.length)
-                    .should('have.prop', 'selectionEnd', '$5'.length);
+                    .should('have.value', '$05 per day')
+                    .should('have.prop', 'selectionStart', '$05'.length)
+                    .should('have.prop', 'selectionEnd', '$05'.length)
+                    .blur()
+                    .should('have.value', '$5 per day');
             });
 
-            it('$0.|05 per day => Backspace => $|5 per day', () => {
+            it('$0.|05 per day => Backspace => blur => $|5 per day', () => {
                 cy.get('@input')
                     .type('0.05')
                     .type('{leftArrow}'.repeat('05'.length))
                     .type('{backspace}')
-                    .should('have.value', '$5 per day')
-                    .should('have.prop', 'selectionStart', '$'.length)
-                    .should('have.prop', 'selectionEnd', '$'.length);
+                    .should('have.value', '$005 per day')
+                    .should('have.prop', 'selectionStart', '$0'.length)
+                    .should('have.prop', 'selectionEnd', '$0'.length)
+                    .blur()
+                    .should('have.value', '$5 per day');
             });
         });
 

--- a/projects/demo-integrations/cypress/tests/kit/number/number-zero-integer-part.cy.ts
+++ b/projects/demo-integrations/cypress/tests/kit/number/number-zero-integer-part.cy.ts
@@ -55,38 +55,44 @@ describe('Number | Zero integer part', () => {
         });
     });
 
-    describe('value cannot start with many leading zeroes', () => {
+    describe('value cannot contain many leading zeroes after blur event', () => {
         it('precision = 2 & positive number', () => {
-            openNumberPage('precision=2');
+            openNumberPage('thousandSeparator=_&precision=2');
 
             cy.get('@input')
                 .type('0000000')
-                .should('have.value', '0')
-                .should('have.prop', 'selectionStart', '0'.length)
-                .should('have.prop', 'selectionEnd', '0'.length);
+                .should('have.value', '0_000_000')
+                .should('have.prop', 'selectionStart', '0_000_000'.length)
+                .should('have.prop', 'selectionEnd', '0_000_000'.length)
+                .blur()
+                .should('have.value', '0');
         });
 
         it('precision = 2 & negative number', () => {
-            openNumberPage('precision=2');
+            openNumberPage('thousandSeparator=_&precision=2');
 
             cy.get('@input')
                 .type('-00000006')
-                .should('have.value', '−6')
-                .should('have.prop', 'selectionStart', '−6'.length)
-                .should('have.prop', 'selectionEnd', '−6'.length);
+                .should('have.value', '−00_000_006')
+                .should('have.prop', 'selectionStart', '−00_000_006'.length)
+                .should('have.prop', 'selectionEnd', '−00_000_006'.length)
+                .blur()
+                .should('have.value', '−6');
         });
 
         it('precision = 0', () => {
-            openNumberPage('precision=0');
+            openNumberPage('thousandSeparator=_&precision=0');
 
             cy.get('@input')
                 .type('0000000')
-                .should('have.value', '0')
-                .should('have.prop', 'selectionStart', '0'.length)
-                .should('have.prop', 'selectionEnd', '0'.length);
+                .should('have.value', '0_000_000')
+                .should('have.prop', 'selectionStart', '0_000_000'.length)
+                .should('have.prop', 'selectionEnd', '0_000_000'.length)
+                .blur()
+                .should('have.value', '0');
         });
 
-        it('1|-000-000 => Backspace => 0', () => {
+        it('1|-000-000 => Backspace => blur => 0', () => {
             openNumberPage('thousandSeparator=_&precision=2');
 
             cy.get('@input')
@@ -94,35 +100,41 @@ describe('Number | Zero integer part', () => {
                 .should('have.value', '1_000_000')
                 .type('{moveToStart}{rightArrow}')
                 .type('{backspace}')
-                .should('have.value', '0')
+                .should('have.value', '000_000')
                 .should('have.prop', 'selectionStart', 0)
-                .should('have.prop', 'selectionEnd', 0);
+                .should('have.prop', 'selectionEnd', 0)
+                .blur()
+                .should('have.value', '0');
         });
-    });
 
-    it('remove leading zeroes when decimal separator is removed (positive number)', () => {
-        openNumberPage('decimalSeparator=,&precision=5');
+        it('remove leading zeroes (on blur only!) when decimal separator is removed (positive number)', () => {
+            openNumberPage('thousandSeparator=_&decimalSeparator=,&precision=5');
 
-        cy.get('@input')
-            .type('0,0005')
-            .type('{moveToStart}{rightArrow}{rightArrow}')
-            .type('{backspace}')
-            .should('have.value', '5')
-            .should('have.prop', 'selectionStart', 0)
-            .should('have.prop', 'selectionEnd', 0);
-    });
+            cy.get('@input')
+                .type('0,0005')
+                .type('{moveToStart}{rightArrow}{rightArrow}')
+                .type('{backspace}')
+                .should('have.value', '00_005')
+                .should('have.prop', 'selectionStart', '00'.length)
+                .should('have.prop', 'selectionEnd', '00'.length)
+                .blur()
+                .should('have.value', '5');
+        });
 
-    it('remove leading zeroes when decimal separator is removed (negative number)', () => {
-        openNumberPage('decimalSeparator=,&precision=5');
+        it('remove leading zeroes (on blur only!) when decimal separator is removed (negative number)', () => {
+            openNumberPage('thousandSeparator=_&decimalSeparator=,&precision=5');
 
-        cy.get('@input')
-            .type('-0,0005')
-            .type('{moveToStart}')
-            .type('{rightArrow}'.repeat('-0,'.length))
-            .type('{backspace}')
-            .should('have.value', '−5')
-            .should('have.prop', 'selectionStart', 1)
-            .should('have.prop', 'selectionEnd', 1);
+            cy.get('@input')
+                .type('-0,0005')
+                .type('{moveToStart}')
+                .type('{rightArrow}'.repeat('-0,'.length))
+                .type('{backspace}')
+                .should('have.value', '−00_005')
+                .should('have.prop', 'selectionStart', '-00'.length)
+                .should('have.prop', 'selectionEnd', '-00'.length)
+                .blur()
+                .should('have.value', '−5');
+        });
     });
 
     describe('pads empty integer part with zero on blur (if decimal part exists)', () => {

--- a/projects/kit/src/lib/masks/number/number-mask.ts
+++ b/projects/kit/src/lib/masks/number/number-mask.ts
@@ -11,10 +11,13 @@ import {
     maskitoPostfixPostprocessorGenerator,
     maskitoPrefixPostprocessorGenerator,
 } from '../../processors';
-import {createMinMaxPlugin, createNotEmptyIntegerPlugin} from './plugins';
+import {
+    createLeadingZeroesValidationPlugin,
+    createMinMaxPlugin,
+    createNotEmptyIntegerPlugin,
+} from './plugins';
 import {
     createDecimalZeroPaddingPostprocessor,
-    createLeadingZeroesValidationPostprocessor,
     createMinMaxPostprocessor,
     createNonRemovableCharsDeletionPreprocessor,
     createNotEmptyIntegerPartPreprocessor,
@@ -76,10 +79,6 @@ export function maskitoNumberOptionsGenerator({
             createRepeatedDecimalSeparatorPreprocessor(decimalSeparator),
         ],
         postprocessors: [
-            createLeadingZeroesValidationPostprocessor(
-                decimalSeparator,
-                thousandSeparator,
-            ),
             createMinMaxPostprocessor({decimalSeparator, min, max}),
             maskitoPrefixPostprocessorGenerator(prefix),
             maskitoPostfixPostprocessorGenerator(postfix),
@@ -97,6 +96,7 @@ export function maskitoNumberOptionsGenerator({
             }),
         ],
         plugins: [
+            createLeadingZeroesValidationPlugin(decimalSeparator, thousandSeparator),
             createNotEmptyIntegerPlugin(decimalSeparator),
             createMinMaxPlugin({min, max, decimalSeparator}),
         ],

--- a/projects/kit/src/lib/masks/number/plugins/index.ts
+++ b/projects/kit/src/lib/masks/number/plugins/index.ts
@@ -1,2 +1,3 @@
+export * from './leading-zeroes-validation.plugin';
 export * from './min-max.plugin';
 export * from './not-empty-integer.plugin';

--- a/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
+++ b/projects/kit/src/lib/masks/number/plugins/leading-zeroes-validation.plugin.ts
@@ -1,0 +1,51 @@
+import {MaskitoPlugin} from '@maskito/core';
+
+import {maskitoEventHandler} from '../../../plugins';
+import {escapeRegExp} from '../../../utils';
+
+/**
+ * It removes repeated leading zeroes for integer part on blur-event.
+ * @example 000000 => blur => 0
+ * @example 00005 => blur => 5
+ */
+export function createLeadingZeroesValidationPlugin(
+    decimalSeparator: string,
+    thousandSeparator: string,
+): MaskitoPlugin {
+    const trimLeadingZeroes = (value: string): string => {
+        const escapedThousandSeparator = escapeRegExp(thousandSeparator);
+
+        return value
+            .replace(
+                // all leading zeroes followed by another zero
+                new RegExp(`^(\\D+)?[0${escapedThousandSeparator}]+(?=0)`),
+                '$1',
+            )
+            .replace(
+                // zero followed by not-zero digit
+                new RegExp(`^(\\D+)?[0${escapedThousandSeparator}]+(?=[1-9])`),
+                '$1',
+            );
+    };
+
+    return maskitoEventHandler(
+        'blur',
+        element => {
+            const {value} = element;
+            const hasDecimalSeparator = value.includes(decimalSeparator);
+            const [integerPart, decimalPart = ''] = value.split(decimalSeparator);
+            const zeroTrimmedIntegerPart = trimLeadingZeroes(integerPart);
+
+            if (integerPart === zeroTrimmedIntegerPart) {
+                return;
+            }
+
+            element.value =
+                zeroTrimmedIntegerPart +
+                (hasDecimalSeparator ? decimalSeparator : '') +
+                decimalPart;
+            element.dispatchEvent(new Event('input'));
+        },
+        {capture: true},
+    );
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Closes #370
